### PR TITLE
Fix for issue #1 by escaping parentheses in output

### DIFF
--- a/fdfgen/__init__.py
+++ b/fdfgen/__init__.py
@@ -8,13 +8,17 @@ and Learning <http://ccnmtl.columbia.edu/>
 """
 
 __author__ = "Anders Pearson <anders@columbia.edu>"
-__credits__ = "Sébastien Fievet <zyegfryed@gmail.com>"
+__credits__ = ("Sébastien Fievet <zyegfryed@gmail.com>,"
+               "Brandon Rhodes <brandon@rhodesmill.org>")
 
 import codecs
 
 
 def smart_encode_str(s):
-    return codecs.BOM_UTF16_BE + unicode(s).encode('utf_16_be').replace('\x00)', '\\\x00)').replace('\x00(', '\\\x00(')
+    """Create a UTF-16 encoded PDF string literal for `s`."""
+    utf16 = s.encode('utf_16_be')
+    safe = utf16.replace('\x00)', '\x00\\)').replace('\x00(', '\x00\\(')
+    return ('%s%s' % (codecs.BOM_UTF16_BE, safe))
 
 
 def handle_hidden(key, fields_hidden):

--- a/fdfgen/tests.py
+++ b/fdfgen/tests.py
@@ -1,0 +1,9 @@
+import fdfgen
+from unittest import TestCase
+
+class Tests(TestCase):
+
+    def test_string_with_unbalanced_paren(self):
+        s = 'a) 1st item'
+        e = '\xfe\xff\x00a\x00\\)\x00 \x001\x00s\x00t\x00 \x00i\x00t\x00e\x00m'
+        self.assertEqual(fdfgen.smart_encode_str(s), e)


### PR DESCRIPTION
As described in issue #1, parentheses were being inserted into the
output FDF without being escaped.  This, especially in the case of
unbalanced parentheses, often produced invalid FDF files that could not
be processed by standard tools.
