### PR TITLE
Encode field names as UTF-16

### DIFF
--- a/fdfgen/__init__.py
+++ b/fdfgen/__init__.py
@@ -65,7 +65,7 @@ def handle_data_strings(fdf_data_strings, fields_hidden, fields_readonly,
         yield b''.join([
             b'<<',
             b'/T(',
-            key,
+            smart_encode_str(key),
             b')',
             b'/V',
             value,

--- a/tests/test_forge_fdf.py
+++ b/tests/test_forge_fdf.py
@@ -1,0 +1,7 @@
+import fdfgen
+
+
+def test_key_encoding():
+    expected_field_name = b'T(\xfe\xff\x00f\x00o\x00o)'  # T(foo) where foo is UTF-16 coded
+    result = fdfgen.forge_fdf(fdf_data_strings=[('foo', 'bar')])
+    assert expected_field_name in result


### PR DESCRIPTION
Currently, the FDF field names are not properly encoded. This happens to work on Python 2 since implicit ASCII conversion is done. Trying to use non-ASCII field names on Python 2 will crash. On Python 3 the code will crash directly. The explicit Python 3 failure can be seen here: https://travis-ci.org/pelme/fdfgen/jobs/162046689#L208

To be able to add a test for this, I've based this PR on PR #18. The important commits in this PR are  e27583e and 	d17af6a. When #18 is merged I can rebase this PR to only include the relevant fix.