### PR TITLE
Handle other 'confusing' characters in identifiers

### DIFF
--- a/fdfgen/__init__.py
+++ b/fdfgen/__init__.py
@@ -48,6 +48,8 @@ class FDFIdentifier(object):
     """A PDF value, such as /Yes or /Off that should be passed through with the / and without parenthesis (which would indicate it was a value, not an identifier)
     This allows for different checkbox checked/unchecked names per checkbox!
     """
+    SPACE_CODE = '#20'
+
     def __init__(self, value):
         if value.startswith('/'):
             value = value[1:]
@@ -55,7 +57,7 @@ class FDFIdentifier(object):
         if isinstance(value, bytes):
             value = value.decode('utf-8')
 
-        value = u'/%s' % value
+        value = u'/%s' % value.replace(' ', self.SPACE_CODE)
         value = value.encode('utf-8')
 
         self._value = value

--- a/fdfgen/__init__.py
+++ b/fdfgen/__init__.py
@@ -17,7 +17,7 @@ import codecs
 import sys
 
 if sys.version_info[0] < 3:
-    bytes = str
+    bytes, str = str, unicode
 
 
 def smart_encode_str(s):
@@ -48,8 +48,6 @@ class FDFIdentifier(object):
     """A PDF value, such as /Yes or /Off that should be passed through with the / and without parenthesis (which would indicate it was a value, not an identifier)
     This allows for different checkbox checked/unchecked names per checkbox!
     """
-    SPACE_CODE = '#20'
-
     def __init__(self, value):
         if value.startswith('/'):
             value = value[1:]
@@ -57,7 +55,7 @@ class FDFIdentifier(object):
         if isinstance(value, bytes):
             value = value.decode('utf-8')
 
-        value = u'/%s' % value.replace(' ', self.SPACE_CODE)
+        value = u'/%s' % re.sub(r'([^\w])', lambda m: "#" + hex(ord(m.group(1)))[-2:], value)
         value = value.encode('utf-8')
 
         self._value = value

--- a/fdfgen/__init__.py
+++ b/fdfgen/__init__.py
@@ -15,6 +15,7 @@ __credits__ = ("Sébastien Fievet <zyegfryed@gmail.com>",
 
 import codecs
 import sys
+import re
 
 if sys.version_info[0] < 3:
     bytes, str = str, unicode

--- a/tests/test_fdf_identifier.py
+++ b/tests/test_fdf_identifier.py
@@ -13,7 +13,7 @@ def test_identifier_without_slash():
     assert result == expected_identifier
 
 
-def test_identifier_with_spaces():
-    expected_identifier = b'/with#20several#20spaces'
-    result = fdfgen.FDFIdentifier('with several spaces').value
+def test_identifier_with_special_chars():
+    expected_identifier = b'/with#20#28several#29#20special#2Fchars'
+    result = fdfgen.FDFIdentifier('with (several) special/chars').value
     assert result == expected_identifier

--- a/tests/test_fdf_identifier.py
+++ b/tests/test_fdf_identifier.py
@@ -11,3 +11,9 @@ def test_identifier_without_slash():
     expected_identifier = b'/Off'
     result = fdfgen.FDFIdentifier('Off').value
     assert result == expected_identifier
+
+
+def test_identifier_with_spaces():
+    expected_identifier = b'/with#20several#20spaces'
+    result = fdfgen.FDFIdentifier('with several spaces').value
+    assert result == expected_identifier


### PR DESCRIPTION
Had specific problems with / as well as space, but thought it safest to just escape anything not "simple" characters.