### PR TITLE
Small modification to alter the encoding of data_fields/checkbox names

### DIFF
--- a/fdfgen/__init__.py
+++ b/fdfgen/__init__.py
@@ -100,7 +100,7 @@ def handle_data_names(fdf_data_names, fields_hidden, fields_readonly):
         fdf_data_names = fdf_data_names.items()
 
     for (key, value) in fdf_data_names:
-        yield b''.join([b'<<\x0a/V /', smart_encode_str(value), b'\x0a/T (',
+        yield b''.join([b'<<\x0a/V /', value.encode("utf-8"), b'\x0a/T (',
                         smart_encode_str(key), b')\x0a',
                         handle_hidden(key, fields_hidden), b'\x0a',
                         handle_readonly(key, fields_readonly), b'\x0a>>\x0a'])


### PR DESCRIPTION
Had some issues with marking checkboxes as filled as pdftk crashed as some encoding characters got inserted into the field value, worked now for me with this small fix.

Error I got from pdftk was: 

Unhandled Java Exception in create_output():
Unhandled Java Exception in main():
java.lang.NullPointerException
   at gnu.gcj.runtime.NameFinder.lookup(libgcj.so.17)
   at java.lang.Throwable.getStackTrace(libgcj.so.17)
   at java.lang.Throwable.stackTraceString(libgcj.so.17)
   at java.lang.Throwable.printStackTrace(libgcj.so.17)
   at java.lang.Throwable.printStackTrace(libgcj.so.17)
